### PR TITLE
Update values.yaml

### DIFF
--- a/charts/stacks/observability/values.yaml
+++ b/charts/stacks/observability/values.yaml
@@ -276,6 +276,11 @@ grafana:
     chart: grafana
     targetRevision: "6.21.0"
   values:
+    deploymentStrategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 1
+      type: RollingUpdate
     persistence:
       enabled: true
       size: 1024Gi


### PR DESCRIPTION
### Description
As the grafana pod has bound a PVC, the rollout fails since the volume cannot be mounted by two pods simultaneously.

### Fixes
