### PR TITLE
add fixed versioning for airflow and vault

### DIFF
--- a/charts/stacks/perfscale/values.yaml
+++ b/charts/stacks/perfscale/values.yaml
@@ -14,7 +14,7 @@ airflow:
   source:
     repoURL: https://airflow.apache.org
     chart: airflow
-    targetRevision: "x.x.x"
+    targetRevision: "1.4.0"
   values: 
     executor: KubernetesExecutor
     defaultAirflowRepository: quay.io/cloud-bulldozer/airflow
@@ -93,7 +93,7 @@ vault:
   source:
     repoURL: https://helm.releases.hashicorp.com
     chart: vault
-    targetRevision: "x.x.x"
+    targetRevision: "0.19.0"
   values:
     global:
       openshift: true


### PR DESCRIPTION
### Description
Currently versioning for upstream airflow and vault is set to "x.x.x" which means pull the latest upstream version, this causes issues when the latest version changes an existing feature or deprecates some functionality being used by our existing infrastructure. 
If we want to make use of new features in future airflow versions, we can first test it on a playground and then change it here. 
