### PR TITLE
remove finalizers to prevent app deletions

### DIFF
--- a/charts/stacks/observability/templates/elastic.yaml
+++ b/charts/stacks/observability/templates/elastic.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.elastic.syncWave | default "0" | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ .Values.global.project }}
   destination: 
@@ -44,8 +42,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.elastic.syncWave | default "0" | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ .Values.global.project }}
   destination: 

--- a/charts/stacks/observability/templates/es-operator.yaml
+++ b/charts/stacks/observability/templates/es-operator.yaml
@@ -4,8 +4,6 @@ kind: Application
 metadata:
   name: {{ .Values.elasticOperator.name | default "eck-operator" }}
   namespace: {{ .Release.Namespace }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   ignoreDifferences:
   - group: admissionregistration.k8s.io

--- a/charts/stacks/observability/templates/grafana.yaml
+++ b/charts/stacks/observability/templates/grafana.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.grafana.syncWave | default "0" | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ .Values.global.project }}
   destination: 

--- a/charts/stacks/observability/templates/loki.yaml
+++ b/charts/stacks/observability/templates/loki.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.loki.syncWave | default "0" | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ .Values.global.project }}
   destination: 

--- a/charts/stacks/observability/templates/promtail.yaml
+++ b/charts/stacks/observability/templates/promtail.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.promtail.syncWave | default "0" | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ .Values.global.project }}
   destination: 

--- a/charts/stacks/observability/templates/thanos.yaml
+++ b/charts/stacks/observability/templates/thanos.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.thanos.syncWave | default "0" | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ .Values.global.project }}
   destination: 

--- a/charts/stacks/perfscale/templates/airflow.yaml
+++ b/charts/stacks/perfscale/templates/airflow.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.airflow.syncWave | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ .Values.global.project }}
   destination: 

--- a/charts/stacks/perfscale/templates/argocd.yaml
+++ b/charts/stacks/perfscale/templates/argocd.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.argocd.syncWave | default "0" | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ .Values.global.project }}
   destination: 

--- a/charts/stacks/perfscale/templates/dashboard.yaml
+++ b/charts/stacks/perfscale/templates/dashboard.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.dashboard.syncWave | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   ignoreDifferences:
   - group: image.openshift.io

--- a/charts/stacks/perfscale/templates/vault.yaml
+++ b/charts/stacks/perfscale/templates/vault.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.vault.syncWave | default "0" | quote }}
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   ignoreDifferences:
   - group: admissionregistration.k8s.io

--- a/clusters/observability.yaml
+++ b/clusters/observability.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   destination: 
@@ -39,8 +37,6 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   destination: 

--- a/clusters/sailplane.yaml
+++ b/clusters/sailplane.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   destination: 


### PR DESCRIPTION
### Description
finalizers need to be removed temporarily since we plan on deleting argo ns and redeploy it as it's currently showing a missing and unhealthy status. 
similar to this issue: https://github.com/argoproj/argo-cd/issues/6046 
