### PR TITLE
Bump grafana chart version

### DIFF
--- a/charts/stacks/observability/values.yaml
+++ b/charts/stacks/observability/values.yaml
@@ -278,7 +278,7 @@ grafana:
   source:
     repoURL: https://grafana.github.io/helm-charts
     chart: grafana
-    targetRevision: "6.21.0"
+    targetRevision: "6.25.1"
   values:
     deploymentStrategy:
       rollingUpdate:


### PR DESCRIPTION
### Description

The 6.25.1 version of the chart provides grafana 8.4.2 (https://github.com/grafana/helm-charts/blob/grafana-6.25.1/charts/grafana/values.yaml#L76) which comes with some interesting features and improvements for barcharts