### PR TITLE
Reduce grafana pvc size and bump chart version

### DIFF
--- a/charts/stacks/observability/values.yaml
+++ b/charts/stacks/observability/values.yaml
@@ -265,7 +265,7 @@ grafana:
   source:
     repoURL: https://grafana.github.io/helm-charts
     chart: grafana
-    targetRevision: "6.25.1"
+    targetRevision: "6.29.4"
   values:
     deploymentStrategy:
       rollingUpdate:
@@ -273,8 +273,9 @@ grafana:
         maxUnavailable: 1
       type: RollingUpdate
     persistence:
+      storageClassName: gp3-csi
       enabled: true
-      size: 1024Gi
+      size: 5Gi
     grafana.ini:
       server:
         domain: grafana.apps.observability.perfscale.devcluster.openshift.com


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

The current PV usage is ~100MiB
```
/var/lib/grafana $ df -h .
Filesystem                Size      Used Available Use% Mounted on
/dev/nvme2n1           1006.9G    105.3M   1006.8G   0% /var/lib/grafana
```

### Fixes
