### PR TITLE
enabling `@` modifier

### DIFF
--- a/charts/stacks/observability/values.yaml
+++ b/charts/stacks/observability/values.yaml
@@ -137,7 +137,7 @@ thanos:
   values:
     image:
       repository: thanosio/thanos
-      tag: v0.22.0
+      tag: v0.24.0
     metrics:
       enabled: true
       serviceMonitor:
@@ -148,6 +148,8 @@ thanos:
       replicaLabel:
         - prometheus_replica
         - replica
+      extraFlags:
+        - "--enable-feature=promql-at-modifier"
     receive:
       enabled: true
       logLevel: debug


### PR DESCRIPTION
### Description
Enabling [this](https://prometheus.io/docs/prometheus/latest/querying/basics/#modifier) feature helps to run query with `@` modifier, helps ranking series on range queries.
ex:
```
bottomk(1,(rate(node_cpu_seconds_total{openshift_cluster_name=~"perf-411-343c.*",mode=~"idle"}[2m] @ 1665105799)))
```
### Fixes
