### PR TITLE
Reduce observability infra

### DIFF
--- a/charts/stacks/observability/values.yaml
+++ b/charts/stacks/observability/values.yaml
@@ -137,7 +137,7 @@ thanos:
   values:
     image:
       repository: thanosio/thanos
-      tag: v0.24.0
+      tag: v0.29.0
     metrics:
       enabled: true
       serviceMonitor:
@@ -154,26 +154,24 @@ thanos:
       enabled: true
       logLevel: debug
       mode: dual-mode
-      nodeSelector:
-        node.kubernetes.io/instance-type: r6i.16xlarge
       tsdbRetention: 14d
       resources:
         requests:
           cpu: 3
-          memory: 450Gi
+          memory: 250Gi
         limits:
-          memory: 450Gi
+          memory: 300Gi
       service:
         additionalHeadless: true
         remoteWrite:
           port: 19291
-      replicaCount: 4
+      replicaCount: 2
       persistence:
         enabled: true
         size: 1024Gi
     receiveDistributor:
       enabled: true
-      replicaCount: 4
+      replicaCount: 2
     storegateway:
       logLevel: debug 
       extraFlags:
@@ -181,11 +179,9 @@ thanos:
       resources:
         requests:
           cpu: 3
-          memory: 100Gi
+          memory: 50Gi
         limits:
-          memory: 200Gi
-      nodeSelector:
-        node.kubernetes.io/instance-type: r6i.16xlarge
+          memory: 100Gi
       enabled: true
       replicaCount: 1
       persistence:
@@ -201,9 +197,11 @@ thanos:
       retentionResolutionRaw: 14d
       retentionResolution5m: 30d
       retentionResolution1h: 60d
+      extraFlags:
+      - --compact.concurrency=4
 
     ruler:
-      enabled: true
+      enabled: false
       alertmanagers:
         - alertmanager-main.openshift-monitoring.svc.cluster.local:9094
       config:
@@ -222,7 +220,7 @@ thanos:
 
 loki:
   name: loki
-  enabled: true
+  enabled: false
   syncWave: 0
   namespace: loki
   source:
@@ -237,11 +235,12 @@ loki:
     config:
       table_manager:
         retention_deletes_enabled: true
+
         retention_period: 14d
 
 promtail: 
   name: promtail
-  enabled: true
+  enabled: false
   syncWave: 0
   namespace: promtail
   source:
@@ -281,6 +280,7 @@ grafana:
     grafana.ini:
       server:
         domain: grafana.apps.observability.perfscale.devcluster.openshift.com
+        root_url: "https://%(domain)s/"
     datasources:
       datasources.yaml:
         apiVersion: 1
@@ -295,9 +295,3 @@ grafana:
           url: http://thanos-query-frontend.thanos.svc.cluster.local:9090
           jsonData:
             timeout: 60
-        - name: Loki 
-          type: loki
-          access: proxy
-          url: http://loki.loki.svc.cluster.local:3100
-
-


### PR DESCRIPTION
 - Bump thanos version                                                    
 - Reduce thanos sizing and remove thanos ruler (not used).               
 - Remove nodeSelector from thanos components. (They'll be automatically scheduled to the big nodes"                                            
 - Disable Loki                                                           
 - Update root_url from grafana, in order to fix the "shorten URL" fature 
   from grafana                                                           


These changes are already in place as they were manually configured in the argocd instance. So this PR is safe to merge

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

cc: @jtaleric @dry923 
