### PR TITLE
Update vault

### DIFF
--- a/charts/stacks/perfscale/values.yaml
+++ b/charts/stacks/perfscale/values.yaml
@@ -93,7 +93,7 @@ vault:
   source:
     repoURL: https://helm.releases.hashicorp.com
     chart: vault
-    targetRevision: "0.19.0"
+    targetRevision: "0.20.1"
   values:
     global:
       openshift: true


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

PodDisruptionBudget from policy/v1beta1 is no longer served as of k8s v1.25, which causing the vault application to fail sync. The new version uses the stable apiVersion of PDBs

cc: @jtaleric 
