### PR TITLE
Revert "Disable remote logging"

### DIFF
--- a/charts/stacks/perfscale/values.yaml
+++ b/charts/stacks/perfscale/values.yaml
@@ -29,6 +29,9 @@ airflow:
         auth_backend: airflow.api.auth.backend.basic_auth
       logging:
         colored_console_log: "True"
+        remote_logging: "True"
+        remote_base_log_folder: s3://perfscale-airflow-logs/ci
+        remote_log_conn_id: S3Logs
       kubernetes:
         delete_worker_pods: True
       core:


### PR DESCRIPTION
W/o this, airflow does not provide logs in the web interface

Reverts cloud-bulldozer/perfscale-stack#22

cc: @jtaleric 